### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/lib/csv_writer.py
+++ b/lib/csv_writer.py
@@ -183,7 +183,7 @@ class ExportPrinter(object):
     if results.get('containsSampledData'):
       sampled_text = 'do'
 
-    row_text = 'These results %s contain sampled data.' % sampled_text
+    row_text = 'These results {0!s} contain sampled data.'.format(sampled_text)
     self.writer.writerow([row_text])
 
   def OutputHeaders(self, results):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:ga-dev-tools?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:ga-dev-tools?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
